### PR TITLE
Fix docs GitHub action

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -38,13 +38,9 @@ jobs:
 
     - name: Build Documentation
       run: |
+        pwd
         export PATH="$PATH:$DEVKITARM/bin"
         cargo doc
-        
-    - name: Upload a Build Artifact
-      uses: actions/upload-artifact@v2.3.1
-      with:
-        path: ./target/doc
         
 
     - name: Deploy Docs

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -44,7 +44,7 @@ jobs:
         
         
     - name: Create an index.html page
-      run: echo "<meta http-equiv="refresh" content="0; URL=nds/index.html" />" >> ./target/doc/index.html
+      run: echo "<meta http-equiv="refresh" content="0; URL=nds/index.html" />" >> ./target/nds/doc/index.html
         
 
     - name: Deploy Docs
@@ -52,5 +52,5 @@ jobs:
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_branch: gh-pages
-        publish_dir: ./target/doc
+        publish_dir: ./target/nds/doc
         force_orphan: true

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,9 +24,8 @@ jobs:
     - name: Install required packages
       shell: bash
       run: |
-        #sudo add-apt-repository "deb http://archive.ubuntu.com/ubuntu $(lsb_release -sc) universe"
         sudo apt-get update
-        sudo apt-get install -y --no-install-recommends gdebi-core apt-utils
+        sudo apt-get install -y --no-install-recommends cc
       
 
     #- name: Install devkitPro
@@ -53,7 +52,9 @@ jobs:
         components: rustfmt, rust-src
 
     - name: Build Documentation
-      run: cargo doc --no-deps --quiet --workspace
+      run: |
+        export PATH="$PATH:$DEVKITARM/bin"
+        cargo doc --no-deps --quiet --workspace
 
     - name: Deploy Docs
       uses: peaceiris/actions-gh-pages@v3.8.0

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,7 +25,7 @@ jobs:
       shell: bash
       run: |
         sudo apt-get update
-        sudo apt-get install -y --no-install-recommends cc
+        sudo apt-get install -y --no-install-recommends gcc
       
 
     #- name: Install devkitPro

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,9 +28,10 @@ jobs:
         sudo apt-get install -y --no-install-recommends apt-utils
         sudo apt-get install -y --no-install-recommends gdebi-core apt-utils
         wget https://github.com/devkitPro/pacman/releases/latest/download/devkitpro-pacman.amd64.deb && sudo gdebi -n devkitpro-pacman.amd64.deb && rm devkitpro-pacman.amd64.deb
-        yes | sudo dkp-pacman -Scc
+        echo -e "y\ny" | sudo dkp-pacman -Scc
         sudo dkp-pacman -Sy
         sudo dkp-pacman -Syu
+        sudo dkp-pacman -Sl
         sudo dkp-pacman -S --noconfirm nds-dev
 
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -44,8 +44,7 @@ jobs:
     - name: Upload a Build Artifact
       uses: actions/upload-artifact@v2.3.1
       with:
-        name: "./target/doc"
-        path: warn
+        path: ./target/doc
         
 
     - name: Deploy Docs

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,22 +25,7 @@ jobs:
       shell: bash
       run: |
         sudo apt-get update
-        sudo apt-get install -y --no-install-recommends gcc build-essential
-      
-
-    #- name: Install devkitPro
-    #  shell: bash
-    #  run: |
-    #    sudo add-apt-repository "deb http://archive.ubuntu.com/ubuntu $(lsb_release -sc) universe"
-    #    sudo apt-get update
-    #    sudo apt-get install -y --no-install-recommends apt-utils
-    #    sudo apt-get install -y --no-install-recommends gdebi-core apt-utils
-    #    wget https://github.com/devkitPro/pacman/releases/latest/download/devkitpro-pacman.amd64.deb && sudo gdebi -n devkitpro-pacman.amd64.deb && rm devkitpro-pacman.amd64.deb
-    #    echo -e "y\ny" | sudo dkp-pacman -Scc
-    #    sudo dkp-pacman -Sy
-    #    sudo dkp-pacman -Syu
-    #    sudo dkp-pacman -Sl
-    #    sudo dkp-pacman -S --noconfirm nds-dev
+        sudo apt-get install -y --no-install-recommends gcc build-essentials
 
 
     - name: Install Rust toolchain

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,6 +21,14 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v2
 
+    - name: Install required packages
+      shell: bash
+      run: |
+        sudo add-apt-repository "deb http://archive.ubuntu.com/ubuntu $(lsb_release -sc) universe"
+        sudo apt-get update¡
+        sudo apt-get install -y --no-install-recommends gdebi-core apt-utils
+      
+
     #- name: Install devkitPro
     #  shell: bash
     #  run: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -40,7 +40,11 @@ jobs:
       run: |
         pwd
         export PATH="$PATH:$DEVKITARM/bin"
-        cargo doc
+        cargo doc --no-deps --open -p nds-sys -p nds
+        
+        
+    - name: Create an index.html page
+      run: echo "<meta http-equiv="refresh" content="0; URL=nds/index.html" />" >> ./target/doc/index.html
         
 
     - name: Deploy Docs

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -40,6 +40,13 @@ jobs:
       run: |
         export PATH="$PATH:$DEVKITARM/bin"
         cargo doc
+        
+    - name: Upload a Build Artifact
+      uses: actions/upload-artifact@v2.3.1
+      with:
+        name: "./target/doc"
+        path: warn
+        
 
     - name: Deploy Docs
       uses: peaceiris/actions-gh-pages@v3.8.0

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,8 +24,8 @@ jobs:
     - name: Install required packages
       shell: bash
       run: |
-        sudo add-apt-repository "deb http://archive.ubuntu.com/ubuntu $(lsb_release -sc) universe"
-        sudo apt-get update¡
+        #sudo add-apt-repository "deb http://archive.ubuntu.com/ubuntu $(lsb_release -sc) universe"
+        sudo apt-get update
         sudo apt-get install -y --no-install-recommends gdebi-core apt-utils
       
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,7 +25,7 @@ jobs:
       shell: bash
       run: |
         sudo apt-get update
-        sudo apt-get install -y --no-install-recommends gcc build-essentials
+        sudo apt-get install -y --no-install-recommends gcc build-essential
 
 
     - name: Install Rust toolchain

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,7 +15,7 @@ env:
 jobs:
   rustdoc:
     runs-on: ubuntu-latest
-    container: devkitpro/devkitarm::latest
+    container: devkitpro/devkitarm:latest
 
     steps:
     - name: Checkout repository

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,7 +25,7 @@ jobs:
       shell: bash
       run: |
         sudo apt-get update
-        sudo apt-get install -y --no-install-recommends gcc
+        sudo apt-get install -y --no-install-recommends gcc build-essential
       
 
     #- name: Install devkitPro

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,24 +15,25 @@ env:
 jobs:
   rustdoc:
     runs-on: ubuntu-latest
+    container: devkitpro/devkitarm::latest
 
     steps:
     - name: Checkout repository
       uses: actions/checkout@v2
 
-    - name: Install devkitPro
-      shell: bash
-      run: |
-        sudo add-apt-repository "deb http://archive.ubuntu.com/ubuntu $(lsb_release -sc) universe"
-        sudo apt-get update
-        sudo apt-get install -y --no-install-recommends apt-utils
-        sudo apt-get install -y --no-install-recommends gdebi-core apt-utils
-        wget https://github.com/devkitPro/pacman/releases/latest/download/devkitpro-pacman.amd64.deb && sudo gdebi -n devkitpro-pacman.amd64.deb && rm devkitpro-pacman.amd64.deb
-        echo -e "y\ny" | sudo dkp-pacman -Scc
-        sudo dkp-pacman -Sy
-        sudo dkp-pacman -Syu
-        sudo dkp-pacman -Sl
-        sudo dkp-pacman -S --noconfirm nds-dev
+    #- name: Install devkitPro
+    #  shell: bash
+    #  run: |
+    #    sudo add-apt-repository "deb http://archive.ubuntu.com/ubuntu $(lsb_release -sc) universe"
+    #    sudo apt-get update
+    #    sudo apt-get install -y --no-install-recommends apt-utils
+    #    sudo apt-get install -y --no-install-recommends gdebi-core apt-utils
+    #    wget https://github.com/devkitPro/pacman/releases/latest/download/devkitpro-pacman.amd64.deb && sudo gdebi -n devkitpro-pacman.amd64.deb && rm devkitpro-pacman.amd64.deb
+    #    echo -e "y\ny" | sudo dkp-pacman -Scc
+    #    sudo dkp-pacman -Sy
+    #    sudo dkp-pacman -Syu
+    #    sudo dkp-pacman -Sl
+    #    sudo dkp-pacman -S --noconfirm nds-dev
 
 
     - name: Install Rust toolchain

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -39,7 +39,7 @@ jobs:
     - name: Build Documentation
       run: |
         export PATH="$PATH:$DEVKITARM/bin"
-        cargo doc --no-deps --quiet --workspace
+        cargo doc
 
     - name: Deploy Docs
       uses: peaceiris/actions-gh-pages@v3.8.0


### PR DESCRIPTION
Some fixes for the `rustdoc` GitHub action:
- Use devKitPro from docker container instead of pacman (see https://github.com/devkitpro/pacman/issues/22)
- Build the docs for the `nds` and `nds-sys` crates exclusively
- index.html page to redirect to the `nds` crate's docs ([Lines 46-47 of the workflow](https://github.com/patataofcourse/nds-rs/tree/master/.github/workflows/docs.yml#L46-L47))
- More verbose logs (even if the warnings are annoying, there's some useful stuff there)

Currently, the page builds as expected, but the index.html page doesn't redirect for some reason?

See https://patataofcourse.github.io/nds-rs/ (or https://patataofcourse.github.io/nds-rs/nds/ if index.html hasn't been fixed yet) for results.